### PR TITLE
use label for storing hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 target/
 pom.xml.tag
 pom.xml.releaseBackup

--- a/src/main/java/com/ibm/jesseg/prometheus/SQLMetricPopulator.java
+++ b/src/main/java/com/ibm/jesseg/prometheus/SQLMetricPopulator.java
@@ -21,7 +21,6 @@ public class SQLMetricPopulator {
   private final String m_sql;
   private volatile long m_numCollections = 0;
 
-
   private final long m_interval;
 
   private PreparedStatement m_statement = null;
@@ -37,9 +36,9 @@ public class SQLMetricPopulator {
   private final Config m_config;
   private ConnectionManager m_connMan;
 
-  public SQLMetricPopulator(AppLogger _logger, CollectorRegistry _registry, Config _config, 
-  ConnectionManager _connMan,
-  long _interval,
+  public SQLMetricPopulator(AppLogger _logger, CollectorRegistry _registry, Config _config,
+      ConnectionManager _connMan,
+      long _interval,
       boolean _isMultiRow,
       String _sql, boolean _includeHostname, String _gaugePrefix)
       throws IOException, SQLException {
@@ -96,7 +95,7 @@ public class SQLMetricPopulator {
     Gauge ret = Gauge.build()
         .name(_gaugeName)
         .help(_help)
-        .labelNames("hostname")
+        .labelNames("hostname", "driver_class")
         .register();
     m_gauges.put(_gaugeName, ret);
     return ret;
@@ -119,10 +118,10 @@ public class SQLMetricPopulator {
 
   private void gatherData() throws SQLException {
     synchronized (m_requestLock) {
-      if (!m_isMultiRow &&  0 == m_gauges.size()) {
+      if (!m_isMultiRow && 0 == m_gauges.size()) {
         return;
       }
-      m_logger.println_verbose("gathering metrics..."+m_sql);
+      m_logger.println_verbose("gathering metrics..." + m_sql);
       try {
         ResultSet rs = getStatement().executeQuery();
         ResultSetMetaData meta = rs.getMetaData();
@@ -152,9 +151,10 @@ public class SQLMetricPopulator {
               }
             }
             double value = rs.getDouble(i);
-            gauge.labels(m_config.getHostNameForDisplay().replaceAll("\\..*", "")).set(value);
+            gauge.labels(m_config.getHostNameForDisplay().replaceAll("\\..*", ""), m_config.getDriverClass())
+                .set(value);
           }
-          if(!m_isMultiRow) {
+          if (!m_isMultiRow) {
             break;
           }
         }

--- a/src/main/java/com/ibm/jesseg/prometheus/SQLMetricPopulator.java
+++ b/src/main/java/com/ibm/jesseg/prometheus/SQLMetricPopulator.java
@@ -94,16 +94,16 @@ public class SQLMetricPopulator {
     }
     m_logger.printfln_verbose("registering gauge: %s", _gaugeName);
     Gauge ret = Gauge.build()
-        .name(_gaugeName).help(_help).register();
+        .name(_gaugeName)
+        .help(_help)
+        .labelNames("hostname")
+        .register();
     m_gauges.put(_gaugeName, ret);
     return ret;
   }
 
   private String getGaugeName(String _columnName, String _rowName) {
     String ret = "";
-    if (m_includeHostname) {
-      ret += m_config.getHostNameForDisplay().replaceAll("\\..*", "") + "__";
-    }
     if (StringUtils.isNonEmpty(m_gaugePrefix)) {
       ret += m_gaugePrefix + "__";
     }
@@ -149,7 +149,7 @@ public class SQLMetricPopulator {
               }
             }
             double value = rs.getDouble(i);
-            gauge.set(value);
+            gauge.labels(m_config.getHostNameForDisplay().replaceAll("\\..*", "")).set(value);
           }
           if(!m_isMultiRow) {
             break;

--- a/src/main/java/com/ibm/jesseg/prometheus/SQLMetricPopulator.java
+++ b/src/main/java/com/ibm/jesseg/prometheus/SQLMetricPopulator.java
@@ -104,6 +104,9 @@ public class SQLMetricPopulator {
 
   private String getGaugeName(String _columnName, String _rowName) {
     String ret = "";
+    if (m_includeHostname) {
+      ret += m_config.getHostNameForDisplay().replaceAll("\\..*", "") + "__";
+    }
     if (StringUtils.isNonEmpty(m_gaugePrefix)) {
       ret += m_gaugePrefix + "__";
     }


### PR DESCRIPTION
addresses #15 

### TODO:
- [x] Add `hostname` label to all metrics
- [x] add `driver_class` label to all metrics
- [ ] Add comments to issue https://github.com/ThePrez/prometheus-exporter-jdbc/issues/6 that we would need some logic to throw an error or ignore `include_hostname` if we're monitoring multiple hosts.

I have implemented support of using the hostname label from `config.json`. This also lets `dashboard.json` be generic by removing unique metrics names from the configuration. 

Here is an example of the dashboard that illustrates the label filtering: 

![image](https://user-images.githubusercontent.com/50843283/225448962-6954cb4a-3ccb-403f-ab55-6089f6107541.png)
