### PR TITLE
Fix CVE by updating Jetty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.56.v20240826</version>
     </dependency>
     <dependency>
       <groupId>net.sf.jt400</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ibm.jesseg</groupId>
   <artifactId>ibmi-prom-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.48.v20220622</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>net.sf.jt400</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ibm.jesseg</groupId>
   <artifactId>ibmi-prom-client</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This seems to fix the CVE and does not break the functionality.  I used maven to compile and build a package successfully.